### PR TITLE
Add a DNS controller class to remove invalid DNS entries

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -23,3 +23,7 @@ voice=female
 start_speaking_ms=3000
 # Milliseconds of silence that decides end of speech
 done_speaking_ms=500
+
+[system]
+# Set to true to enable checking the DNS configuration to remove invalid entries
+dns=false

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -29,6 +29,7 @@
 #include "spotifyd.hpp"
 #include "stt.hpp"
 #include "wsclient.hpp"
+#include "dns_controller.hpp"
 
 double time_diff(struct timeval x, struct timeval y) {
   return (((double)y.tv_sec * 1000000 + (double)y.tv_usec) -
@@ -76,6 +77,9 @@ int genie::App::exec() {
 
   m_leds = std::make_unique<Leds>(this);
   m_leds->init();
+
+  if (m_config->dns_controller_enabled)
+    m_dns_controller = std::make_unique<DNSController>();
 
   g_debug("start main loop\n");
   g_main_loop_run(main_loop);
@@ -170,7 +174,7 @@ void genie::App::handle(ActionType type, gpointer payload) {
       if (ev->type == 1 && ev->code == KEY_VOLUMEDOWN && ev->value == 1) {
         m_audioPlayer->decrement_playback_volume();
       }
-      
+
       g_free(ev);
       // long volume = m_audioPlayer->get_volume();
       // g_message("Volume: %ld", volume);

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -24,7 +24,6 @@
 #include <glib.h>
 #include <memory>
 #include <sys/time.h>
-#include "libevdev/libevdev.h"
 
 #define PROF_PRINT(...)                                                        \
   do {                                                                         \
@@ -59,6 +58,7 @@ class Spotifyd;
 class STT;
 class TTS;
 class wsClient;
+class DNSController;
 
 enum ProcesingEvent_t {
   PROCESSING_BEGIN = 0,
@@ -107,6 +107,7 @@ public:
   std::unique_ptr<Spotifyd> m_spotifyd;
   std::unique_ptr<STT> m_stt;
   std::unique_ptr<wsClient> m_wsClient;
+  std::unique_ptr<DNSController> m_dns_controller;
 
 protected:
   void handle(ActionType type, gpointer payload);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -21,6 +21,9 @@
 #include <glib.h>
 #include <string.h>
 
+#include <memory>
+#include "autoptrs.hpp"
+
 genie::Config::Config() {}
 
 genie::Config::~Config() {
@@ -51,7 +54,8 @@ gchar *genie::Config::get_string(GKeyFile *key_file, const char *section,
 }
 
 void genie::Config::load() {
-  GKeyFile *key_file = g_key_file_new();
+  std::unique_ptr<GKeyFile, fn_deleter<GKeyFile, g_key_file_free>> auto_key_file(g_key_file_new());
+  GKeyFile *key_file = auto_key_file.get();
   GError *error = NULL;
 
   if (!g_key_file_load_from_file(key_file, "config.ini",
@@ -60,171 +64,171 @@ void genie::Config::load() {
                                  &error)) {
     g_print("config load error: %s\n", error->message);
     g_error_free(error);
-  } else {
-    genieURL = g_key_file_get_string(key_file, "general", "url", &error);
-    if (error || (genieURL && strlen(genieURL) == 0)) {
-      genieURL = g_strdup("wss://almond.stanford.edu/me/api/conversation");
-    }
-    error = NULL;
-    genieAccessToken =
-        g_key_file_get_string(key_file, "general", "accessToken", &error);
-    if (error) {
-      g_error("Missing access token in config file");
-      return;
-    }
-
-    error = NULL;
-    nlURL = g_key_file_get_string(key_file, "general", "nlUrl", &error);
-    g_debug("genieURL: %s\ngenieAccessToken: %s\nnlURL: %s\n", genieURL,
-            genieAccessToken, nlURL);
-    if (error) {
-      g_error("Missing NLP URL in config file");
-      return;
-    }
-
-    error = NULL;
-    conversationId =
-        g_key_file_get_string(key_file, "general", "conversationId", &error);
-    if (error) {
-      g_message("No conversation ID in config file, using xiaodu");
-      conversationId = g_strdup("xiaodu");
-      g_error_free(error);
-    } else {
-      g_debug("conversationId: %s\n", conversationId);
-    }
-
-    error = NULL;
-    audioInputDevice =
-        g_key_file_get_string(key_file, "audio", "input", &error);
-    if (error) {
-      g_warning("Missing audio input device in configuration file");
-      audioInputDevice = g_strdup("hw:0,0");
-      g_error_free(error);
-      return;
-    }
-
-    error = NULL;
-    audioSink = g_key_file_get_string(key_file, "audio", "sink", &error);
-    if (error) {
-      audioSink = g_strdup("autoaudiosink");
-      audioOutputDeviceMusic = NULL;
-      audioOutputDeviceVoice = NULL;
-      audioOutputDeviceAlerts = NULL;
-      g_error_free(error);
-    } else {
-      error = NULL;
-
-      gchar *output =
-          g_key_file_get_string(key_file, "audio", "output", &error);
-      if (error) {
-        g_error_free(error);
-        output = g_strdup("hw:0,0");
-      }
-
-      error = NULL;
-      audioOutputDeviceMusic =
-          g_key_file_get_string(key_file, "audio", "music_output", &error);
-      if (error) {
-        g_error_free(error);
-        audioOutputDeviceMusic = g_strdup(output);
-      }
-
-      error = NULL;
-      audioOutputDeviceVoice =
-          g_key_file_get_string(key_file, "audio", "voice_output", &error);
-      if (error) {
-        g_error_free(error);
-        audioOutputDeviceVoice = g_strdup(output);
-      }
-
-      error = NULL;
-      audioOutputDeviceAlerts =
-          g_key_file_get_string(key_file, "audio", "alert_output", &error);
-      if (error) {
-        g_error_free(error);
-        audioOutputDeviceAlerts = g_strdup(output);
-      }
-
-      g_free(output);
-    }
-
-    error = NULL;
-    audioOutputFIFO = g_key_file_get_string(key_file, "audio", "output_fifo", &error);
-    if (error) {
-      g_error_free(error);
-      audioOutputFIFO = g_strdup("/tmp/playback.fifo");
-    }
-
-    error = NULL;
-    audioVoice = g_key_file_get_string(key_file, "audio", "voice", &error);
-    if (error) {
-      g_error_free(error);
-      audioVoice = g_strdup("female");
-    }
-
-    error = NULL;
-    vad_start_speaking_ms =
-        g_key_file_get_integer(key_file, "vad", "start_speaking_ms", &error);
-    if (error) {
-      g_error_free(error);
-      vad_start_speaking_ms = DEFAULT_VAD_START_SPEAKING_MS;
-    }
-    if (vad_start_speaking_ms < VAD_MIN_MS) {
-      g_warning("CONFIG [vad] start_speaking_ms must be %d or greater, "
-                "found %d. Setting to default (%d).",
-                VAD_MIN_MS, vad_start_speaking_ms,
-                DEFAULT_VAD_START_SPEAKING_MS);
-      vad_start_speaking_ms = DEFAULT_VAD_START_SPEAKING_MS;
-    }
-    if (vad_start_speaking_ms > VAD_MAX_MS) {
-      g_warning("CONFIG [vad] start_speaking_ms must be %d or less, "
-                "found %d. Setting to default (%d).",
-                VAD_MAX_MS, vad_start_speaking_ms,
-                DEFAULT_VAD_START_SPEAKING_MS);
-      vad_start_speaking_ms = DEFAULT_VAD_START_SPEAKING_MS;
-    }
-
-    error = NULL;
-    vad_done_speaking_ms =
-        g_key_file_get_integer(key_file, "vad", "done_speaking_ms", &error);
-    if (error) {
-      g_error_free(error);
-      vad_done_speaking_ms = DEFAULT_VAD_DONE_SPEAKING_MS;
-    }
-    if (vad_done_speaking_ms < VAD_MIN_MS) {
-      g_warning("CONFIG [vad] done_speaking_ms must be %d or greater, "
-                "found %d. Setting to default (%d).",
-                VAD_MIN_MS, vad_done_speaking_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
-      vad_done_speaking_ms = DEFAULT_VAD_DONE_SPEAKING_MS;
-    }
-    if (vad_done_speaking_ms > VAD_MAX_MS) {
-      g_warning("CONFIG [vad] done_speaking_ms must be %d or less, "
-                "found %d. Setting to default (%d).",
-                VAD_MAX_MS, vad_done_speaking_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
-      vad_done_speaking_ms = DEFAULT_VAD_DONE_SPEAKING_MS;
-    }
-
-    error = NULL;
-    vad_min_woke_ms =
-        g_key_file_get_integer(key_file, "vad", "min_woke_ms", &error);
-    if (error) {
-      g_error_free(error);
-      vad_min_woke_ms = DEFAULT_MIN_WOKE_MS;
-    }
-    if (vad_min_woke_ms < VAD_MIN_MS) {
-      g_warning("CONFIG [vad] min_woke_ms must be %d or greater, "
-                "found %d. Setting to default (%d).",
-                VAD_MIN_MS, vad_min_woke_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
-      vad_min_woke_ms = DEFAULT_MIN_WOKE_MS;
-    }
-    if (vad_min_woke_ms > VAD_MAX_MS) {
-      g_warning("CONFIG [vad] min_woke_ms must be %d or less, "
-                "found %d. Setting to default (%d).",
-                VAD_MAX_MS, vad_min_woke_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
-      vad_min_woke_ms = DEFAULT_MIN_WOKE_MS;
-    }
-
-    audio_output_device =
-        get_string(key_file, "audio", "output", DEFAULT_AUDIO_OUTPUT_DEVICE);
+    return;
   }
+
+  genieURL = g_key_file_get_string(key_file, "general", "url", &error);
+  if (error || (genieURL && strlen(genieURL) == 0)) {
+    genieURL = g_strdup("wss://almond.stanford.edu/me/api/conversation");
+  }
+  error = NULL;
+  genieAccessToken =
+      g_key_file_get_string(key_file, "general", "accessToken", &error);
+  if (error) {
+    g_error("Missing access token in config file");
+    return;
+  }
+
+  error = NULL;
+  nlURL = g_key_file_get_string(key_file, "general", "nlUrl", &error);
+  g_debug("genieURL: %s\ngenieAccessToken: %s\nnlURL: %s\n", genieURL,
+          genieAccessToken, nlURL);
+  if (error) {
+    g_error("Missing NLP URL in config file");
+    return;
+  }
+
+  error = NULL;
+  conversationId =
+      g_key_file_get_string(key_file, "general", "conversationId", &error);
+  if (error) {
+    g_message("No conversation ID in config file, using xiaodu");
+    conversationId = g_strdup("xiaodu");
+    g_error_free(error);
+  } else {
+    g_debug("conversationId: %s\n", conversationId);
+  }
+
+  error = NULL;
+  audioInputDevice = g_key_file_get_string(key_file, "audio", "input", &error);
+  if (error) {
+    g_warning("Missing audio input device in configuration file");
+    audioInputDevice = g_strdup("hw:0,0");
+    g_error_free(error);
+    return;
+  }
+
+  error = NULL;
+  audioSink = g_key_file_get_string(key_file, "audio", "sink", &error);
+  if (error) {
+    audioSink = g_strdup("autoaudiosink");
+    audioOutputDeviceMusic = NULL;
+    audioOutputDeviceVoice = NULL;
+    audioOutputDeviceAlerts = NULL;
+    g_error_free(error);
+  } else {
+    error = NULL;
+
+    gchar *output = g_key_file_get_string(key_file, "audio", "output", &error);
+    if (error) {
+      g_error_free(error);
+      output = g_strdup("hw:0,0");
+    }
+
+    error = NULL;
+    audioOutputDeviceMusic =
+        g_key_file_get_string(key_file, "audio", "music_output", &error);
+    if (error) {
+      g_error_free(error);
+      audioOutputDeviceMusic = g_strdup(output);
+    }
+
+    error = NULL;
+    audioOutputDeviceVoice =
+        g_key_file_get_string(key_file, "audio", "voice_output", &error);
+    if (error) {
+      g_error_free(error);
+      audioOutputDeviceVoice = g_strdup(output);
+    }
+
+    error = NULL;
+    audioOutputDeviceAlerts =
+        g_key_file_get_string(key_file, "audio", "alert_output", &error);
+    if (error) {
+      g_error_free(error);
+      audioOutputDeviceAlerts = g_strdup(output);
+    }
+
+    g_free(output);
+  }
+
+  error = NULL;
+  audioOutputFIFO =
+      g_key_file_get_string(key_file, "audio", "output_fifo", &error);
+  if (error) {
+    g_error_free(error);
+    audioOutputFIFO = g_strdup("/tmp/playback.fifo");
+  }
+
+  error = NULL;
+  audioVoice = g_key_file_get_string(key_file, "audio", "voice", &error);
+  if (error) {
+    g_error_free(error);
+    audioVoice = g_strdup("female");
+  }
+
+  error = NULL;
+  vad_start_speaking_ms =
+      g_key_file_get_integer(key_file, "vad", "start_speaking_ms", &error);
+  if (error) {
+    g_error_free(error);
+    vad_start_speaking_ms = DEFAULT_VAD_START_SPEAKING_MS;
+  }
+  if (vad_start_speaking_ms < VAD_MIN_MS) {
+    g_warning("CONFIG [vad] start_speaking_ms must be %d or greater, "
+              "found %d. Setting to default (%d).",
+              VAD_MIN_MS, vad_start_speaking_ms, DEFAULT_VAD_START_SPEAKING_MS);
+    vad_start_speaking_ms = DEFAULT_VAD_START_SPEAKING_MS;
+  }
+  if (vad_start_speaking_ms > VAD_MAX_MS) {
+    g_warning("CONFIG [vad] start_speaking_ms must be %d or less, "
+              "found %d. Setting to default (%d).",
+              VAD_MAX_MS, vad_start_speaking_ms, DEFAULT_VAD_START_SPEAKING_MS);
+    vad_start_speaking_ms = DEFAULT_VAD_START_SPEAKING_MS;
+  }
+
+  error = NULL;
+  vad_done_speaking_ms =
+      g_key_file_get_integer(key_file, "vad", "done_speaking_ms", &error);
+  if (error) {
+    g_error_free(error);
+    vad_done_speaking_ms = DEFAULT_VAD_DONE_SPEAKING_MS;
+  }
+  if (vad_done_speaking_ms < VAD_MIN_MS) {
+    g_warning("CONFIG [vad] done_speaking_ms must be %d or greater, "
+              "found %d. Setting to default (%d).",
+              VAD_MIN_MS, vad_done_speaking_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
+    vad_done_speaking_ms = DEFAULT_VAD_DONE_SPEAKING_MS;
+  }
+  if (vad_done_speaking_ms > VAD_MAX_MS) {
+    g_warning("CONFIG [vad] done_speaking_ms must be %d or less, "
+              "found %d. Setting to default (%d).",
+              VAD_MAX_MS, vad_done_speaking_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
+    vad_done_speaking_ms = DEFAULT_VAD_DONE_SPEAKING_MS;
+  }
+
+  error = NULL;
+  vad_min_woke_ms =
+      g_key_file_get_integer(key_file, "vad", "min_woke_ms", &error);
+  if (error) {
+    g_error_free(error);
+    vad_min_woke_ms = DEFAULT_MIN_WOKE_MS;
+  }
+  if (vad_min_woke_ms < VAD_MIN_MS) {
+    g_warning("CONFIG [vad] min_woke_ms must be %d or greater, "
+              "found %d. Setting to default (%d).",
+              VAD_MIN_MS, vad_min_woke_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
+    vad_min_woke_ms = DEFAULT_MIN_WOKE_MS;
+  }
+  if (vad_min_woke_ms > VAD_MAX_MS) {
+    g_warning("CONFIG [vad] min_woke_ms must be %d or less, "
+              "found %d. Setting to default (%d).",
+              VAD_MAX_MS, vad_min_woke_ms, DEFAULT_VAD_DONE_SPEAKING_MS);
+    vad_min_woke_ms = DEFAULT_MIN_WOKE_MS;
+  }
+
+  audio_output_device =
+      get_string(key_file, "audio", "output", DEFAULT_AUDIO_OUTPUT_DEVICE);
+
+  dns_controller_enabled = g_key_file_get_boolean(key_file, "system", "dns", nullptr);
 }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -56,6 +56,8 @@ public:
    */
   gchar *audio_output_device;
 
+  bool dns_controller_enabled;
+
 protected:
 private:
   gchar *get_string(GKeyFile *key_file, const char *section, const char *key,

--- a/src/dns_controller.cpp
+++ b/src/dns_controller.cpp
@@ -1,0 +1,107 @@
+// -*- mode: cpp; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dns_controller.hpp"
+
+#include <memory>
+#include <sstream>
+#include <cstdio>
+
+genie::DNSController::DNSController() {
+  g_debug("Initializing DNS controller...");
+
+  update_dns_config();
+
+  auto_gobject_ptr<GFile> file(g_file_new_for_path("/data/wifi/resolv.conf"),
+                               adopt_mode::owned);
+
+  GError *error = nullptr;
+  m_file_monitor = auto_gobject_ptr<GFileMonitor>(
+      g_file_monitor(file.get(), G_FILE_MONITOR_NONE, nullptr, &error),
+      adopt_mode::owned);
+  if (error) {
+    g_critical("Failed to install file monitor for DNS configuration: %s",
+               error->message);
+    g_error_free(error);
+    return;
+  }
+
+  g_signal_connect(m_file_monitor.get(), "changed", G_CALLBACK(on_changed),
+                   this);
+}
+
+genie::DNSController::~DNSController() {
+  if (m_file_monitor)
+    g_object_run_dispose(G_OBJECT(m_file_monitor.get()));
+}
+
+void genie::DNSController::on_changed(GFileMonitor *monitor, GFile *file,
+                                      GFile *other_file,
+                                      GFileMonitorEvent event, gpointer data) {
+  DNSController *self = static_cast<DNSController *>(data);
+  self->update_dns_config();
+}
+
+void genie::DNSController::update_dns_config() {
+  g_debug("Updating DNS configuration...");
+
+  char *contents;
+  size_t size;
+  GError *error = nullptr;
+  if (!g_file_get_contents("/data/wifi/resolv.conf", &contents, &size, &error)) {
+    g_warning("Failed to read new DNS configuration: %s", error->message);
+    g_error_free(error);
+    return;
+  }
+
+  std::unique_ptr<char *, fn_deleter<char *, g_strfreev>> lines(
+      g_strsplit(contents, "\n", -1));
+  g_free(contents);
+
+  std::ostringstream new_buffer;
+
+  bool any_change = false;
+  bool any_nameserver = false;
+  for (int i = 0; lines.get()[i]; i++) {
+    const char *line = lines.get()[i];
+    if (!*line)
+      continue;
+
+    if (g_str_has_suffix(line, " 114.114.114.114")) {
+      g_debug("Found bad DNS configuration line");
+      any_change = true;
+      continue;
+    }
+    if (g_str_has_prefix(line, "nameserver "))
+      any_nameserver = true;
+
+    new_buffer << line << '\n';
+  }
+  if (!any_change)
+    return;
+  if (!any_nameserver)
+    new_buffer << "nameserver 8.8.8.8" << std::endl;
+
+  std::string new_contents(new_buffer.str());
+  if (!g_file_set_contents("/data/wifi/resolv.conf", new_contents.c_str(), -1,
+                           &error)) {
+    g_warning("Failed to write new DNS configuration: %s", error->message);
+    g_error_free(error);
+    return;
+  }
+}

--- a/src/dns_controller.hpp
+++ b/src/dns_controller.hpp
@@ -16,40 +16,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _EVINPUT_H
-#define _EVINPUT_H
+#ifndef _DNS_CONTROLLER_H
+#define _DNS_CONTROLLER_H
 
-#include "app.hpp"
+#include <glib.h>
+#include <gio/gio.h>
 
-#include <libevdev/libevdev.h>
+#include "autoptrs.hpp"
 
 namespace genie {
 
-struct InputEventSource {
-  GSource source;
-  struct libevdev *device;
-  GPollFD event_poll_fd;
-};
 
-class EVInput {
-public:
-  EVInput(App *app);
-  ~EVInput();
-  int init();
-
+class DNSController {
 private:
-  App *app;
-  static gboolean event_prepare(GSource *source, gint *timeout);
-  static gboolean event_check(GSource *source);
-  static gboolean event_dispatch(GSource *g_source, GSourceFunc callback,
-                                 gpointer user_data);
-  static gboolean callback(gpointer user_data);
+    auto_gobject_ptr<GFileMonitor> m_file_monitor;
+    static void on_changed(GFileMonitor *monitor, GFile *file, GFile *other_file, GFileMonitorEvent event, gpointer self);
+    void update_dns_config();
 
-  GSourceFuncs event_funcs = {event_prepare, event_check, event_dispatch,
-                              NULL,          NULL,        NULL};
-  GSource *source;
+public:
+    DNSController();
+    ~DNSController();
+
+    DNSController(const DNSController&) = delete;
+    DNSController& operator=(const DNSController&) = delete;
 };
 
-} // namespace genie
+}
 
 #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -81,6 +81,7 @@ executable(
   'audioplayer.cpp',
   'stt.cpp',
   'spotifyd.cpp',
+  'dns_controller.cpp',
   link_args : _linkArgs,
   install : true,
   dependencies : _deps


### PR DESCRIPTION
In case the OS DNS management includes unwanted entries, watch
/etc/resolv.conf for changes and remove those entries.

This is controlled by a "dns" option in the [system] section of
the config file.