### PR TITLE
Wip/nrser/vsc dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,60 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/docker-existing-dockerfile
+// 
+// You'll also want this in `/.vscode/c_cpp_properties.json` for VSCode to
+// figure out the C++ setup (header locations, compiler, etc.):
+// 
+// 		{
+// 			"configurations": [
+// 					{
+// 							"name": "Linux arm32v7 container",
+// 							"intelliSenseMode": "gcc-arm",
+// 							"compileCommands": "/src/build/compile_commands.json"
+// 					}
+// 			],
+// 			"version": 4
+// 		}
+// 
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../scripts/Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.cpptools",
+		"streetsidesoftware.code-spell-checker",
+	],
+	
+	// This did _not_ work... seemed to have build using it, but then brought up
+	// an x86 container for the workspace..?
+	// "initializeCommand": [
+	// 	"docker",
+	// 	"build",
+	// 	"--build-arg",
+	// 	"ARCH=arm32v7/",
+	// 	"."
+	// ],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,7 @@
 	"extensions": [
 		"ms-vscode.cpptools",
 		"streetsidesoftware.code-spell-checker",
+		"asabil.meson",
 	],
 	
 	// This did _not_ work... seemed to have build using it, but then brought up

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 assets/*
 !assets/.gitkeep
 !assets/news-intro.oga
-build/
+/build/
 /tmp/
 
 # macOS Finder artifact

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 assets/*
 !assets/.gitkeep
 !assets/news-intro.oga
+# Meson build directory
 /build/
+# Build output directory
+/out/
+# Place for assorted temporary files
 /tmp/
 
 # macOS Finder artifact

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ assets/*
 !assets/news-intro.oga
 build/
 /tmp/
+
+# macOS Finder artifact
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/tinyfsm"]
+	path = deps/tinyfsm
+	url = https://github.com/digint/tinyfsm.git

--- a/cli/genie_client_cpp/cmd/build.py
+++ b/cli/genie_client_cpp/cmd/build.py
@@ -56,17 +56,22 @@ def run(
 ):
     tag = f"genie-builder:{arch}"
 
+    opts = {
+        "build-arg": [
+            f"ARCH={arch}/", # TODO Why is this `/` added here?
+            f"STATIC={int(static)}"
+        ],
+        "tag": tag,
+        "file": CFG.genie_client_cpp.paths.scripts.dockerfile,
+    }
+
+    if plain:
+        opts["progress"] = "plain"
+
     sh.run(
         "docker",
         "build",
-        {
-            "build-arg": [
-                f"ARCH={arch}/", # TODO Why is this `/` added here?
-                f"STATIC={int(static)}"
-            ],
-            "tag": tag,
-            "file": CFG.genie_client_cpp.paths.scripts.dockerfile,
-        },
+        opts,
         ".",
         chdir=CFG.genie_client_cpp.paths.repo,
         log=LOG,
@@ -79,20 +84,15 @@ def run(
     else:
         script = "/src/scripts/blob.sh"
 
-    opts = {
-        "rm": True,
-        "volume": f"{CFG.genie_client_cpp.paths.out.root}:/out",
-        "security-opt": "label=disable",
-        "env": f"ARCH={arch}",
-    }
-
-    if plain:
-        opts["progress"] = "plain"
-
     sh.run(
         "docker",
         "run",
-        opts,
+        {
+            "rm": True,
+            "volume": f"{CFG.genie_client_cpp.paths.out.root}:/out",
+            "security-opt": "label=disable",
+            "env": f"ARCH={arch}",
+        },
         tag,
         script,
         chdir=CFG.genie_client_cpp.paths.repo,

--- a/cli/genie_client_cpp/cmd/build.py
+++ b/cli/genie_client_cpp/cmd/build.py
@@ -72,7 +72,7 @@ def run(arch: str = DEFAULT_ARCH, static: bool = False, exe_only: bool = False):
         "run",
         {
             "rm": True,
-            "volume": f"{CFG.genie_client_cpp.paths.build.root}:/out",
+            "volume": f"{CFG.genie_client_cpp.paths.out.root}:/out",
             "security-opt": "label=disable",
             "env": f"ARCH={arch}",
         },

--- a/cli/genie_client_cpp/cmd/context/__init__.py
+++ b/cli/genie_client_cpp/cmd/context/__init__.py
@@ -1,12 +1,14 @@
+from genie_client_cpp.context import Context
+
 def add_to(subparsers):
     parser = subparsers.add_parser(
         "context",
         target=run,
-        help="Get and set context values (in repo's Git config)",
+        help="List available contexts (in repo's Git config)",
     )
 
     parser.add_children(__name__, __path__)
 
 
-def run():
-    return "HERE"
+def run(list: bool = False):
+    return Context.list()

--- a/cli/genie_client_cpp/cmd/context/get.py
+++ b/cli/genie_client_cpp/cmd/context/get.py
@@ -1,0 +1,41 @@
+from clavier import sh, log as logging
+
+from genie_client_cpp.context import Context
+
+LOG = logging.getLogger(__name__)
+
+def add_to(subparsers):
+    parser = subparsers.add_parser(
+        "get",
+        target=get_context,
+        help="Get values in a context",
+    )
+
+    # parser.add_argument(
+    #     "-t",
+    #     "--target",
+    # )
+
+    # parser.add_argument(
+    #     "-n",
+    #     "--wifi-name",
+    # )
+
+    # parser.add_argument(
+    #     "-p",
+    #     "--wifi-password",
+    # )
+
+    # parser.add_argument(
+    #     "-d",
+    #     "--dns-servers",
+    #     help="DNS servers to set in resolv.conf"
+    # )
+
+    parser.add_argument(
+        "context",
+        help="Name of context",
+    )
+
+def get_context(context):
+    return Context.load(context)

--- a/cli/genie_client_cpp/cmd/deploy.py
+++ b/cli/genie_client_cpp/cmd/deploy.py
@@ -18,7 +18,7 @@ COMMANDS_TO_KILL = (
     re.compile(r"^/tmp/spotifyd\s"),
 )
 
-BUILD_PATHS = CFG.genie_client_cpp.paths.build
+OUT_PATHS = CFG.genie_client_cpp.paths.out
 SCRIPT_PATHS = CFG.genie_client_cpp.paths.scripts
 DEPLOY_PATHS = CFG.genie_client_cpp.xiaodu.paths
 
@@ -73,25 +73,25 @@ def deploy_all(target: str, log=LOG):
     remote = Remote.create(target)
 
     remote.run("mkdir", "-p", CFG.genie_client_cpp.xiaodu.paths.install)
-    remote.push(BUILD_PATHS.lib, DEPLOY_PATHS.lib)
-    remote.push(BUILD_PATHS.assets, DEPLOY_PATHS.assets)
+    remote.push(OUT_PATHS.lib, DEPLOY_PATHS.lib)
+    remote.push(OUT_PATHS.assets, DEPLOY_PATHS.assets)
     remote.push(SCRIPT_PATHS.launch, DEPLOY_PATHS.launch)
     remote.push(SCRIPT_PATHS.asoundrc, DEPLOY_PATHS.asoundrc)
-    remote.push(BUILD_PATHS.config, DEPLOY_PATHS.config)
-    remote.push(BUILD_PATHS.exe, DEPLOY_PATHS.exe)
+    remote.push(OUT_PATHS.config, DEPLOY_PATHS.config)
+    remote.push(OUT_PATHS.exe, DEPLOY_PATHS.exe)
 
 
 @LOG.inject
 def deploy_exe(target: str, log=LOG):
     log.info("Deploying executable...")
     kill.run(target)
-    Remote.create(target).push(BUILD_PATHS.exe, DEPLOY_PATHS.exe)
+    Remote.create(target).push(OUT_PATHS.exe, DEPLOY_PATHS.exe)
 
 
 @LOG.inject
 def deploy_config(target: str, log=LOG):
     log.info("Deploying config file...")
-    Remote.create(target).push(BUILD_PATHS.config, DEPLOY_PATHS.config)
+    Remote.create(target).push(OUT_PATHS.config, DEPLOY_PATHS.config)
 
 
 @Context.inject_current

--- a/cli/genie_client_cpp/config.py
+++ b/cli/genie_client_cpp/config.py
@@ -14,12 +14,12 @@ with CFG.configure("genie_client_cpp", src=__file__) as client:
         with paths.configure("cli") as cli:
             cli.root = paths.repo / "cli"
 
-        with paths.configure("build") as build:
-            build.root = paths.repo / "build"
-            build.assets = build.root / "assets"
-            build.lib = build.root / "lib"
-            build.config = build.root / "config.ini"
-            build.exe = build.root / "src" / "genie"
+        with paths.configure("out") as out:
+            out.root = paths.repo / "out"
+            out.assets = out.root / "assets"
+            out.lib = out.root / "lib"
+            out.config = out.root / "config.ini"
+            out.exe = out.root / "src" / "genie"
 
         with paths.configure("scripts") as scripts:
             scripts.root = paths.repo / "scripts"

--- a/cli/genie_client_cpp/context.py
+++ b/cli/genie_client_cpp/context.py
@@ -41,6 +41,7 @@ class Context:
             value = sh.get(
                 "git",
                 "config",
+                "--local",
                 cls.git_config_name(key_path),
                 format="strip",
             )
@@ -64,6 +65,7 @@ class Context:
             sh.run(
                 "git",
                 "config",
+                "--local",
                 cls.git_config_name(key_path),
                 cls.encode(value),
             )
@@ -86,6 +88,22 @@ class Context:
                     )
             return cls.LIST_SEP.join(value)
         raise TypeError(f"can't encode type {type(value)}: {repr(value)}")
+
+    @classmethod
+    def list(cls):
+        config_names = sh.get(
+            "git",
+            "config",
+            "--local",
+            "--list",
+        ).splitlines()
+
+        return sorted({
+            parts[1]
+            for parts
+            in (name.split(".") for name in config_names)
+            if parts[0] == cls.GIT_CONFIG_PREFIX and len(parts) > 2
+        })
 
     @classmethod
     def get_current_name(cls):

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,7 @@
-ARG ARCH=
+# NOTE  I defaulted `ARCH` to the xiaodu architecture because it was how I was
+#       able to run VSCode in the container -- couldn't get the IDE to provide
+#       the right build arg to bring up an `arm32v7` container.
+ARG ARCH=arm32v7/
 ARG STATIC=0
 FROM ${ARCH}debian:stretch-slim
 ARG ARCH

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -43,12 +43,12 @@ fi
 
 # copy the artifacts to the output directory
 if [ ${BLOB} -eq 1 ]; then
-	docker run --rm -v $(pwd)/build:/out --security-opt label=disable -e ARCH=${ARCH} genie-builder:${ARCH} /src/scripts/blob.sh
+	docker run --rm -v $(pwd)/out:/out --security-opt label=disable -e ARCH=${ARCH} genie-builder:${ARCH} /src/scripts/blob.sh
 	exit ${?}
 fi
 
 if [ ${LIGHT} -eq 1 ]; then
-	docker run --rm -v $(pwd)/build:/out --security-opt label=disable -e ARCH=${ARCH} genie-builder:${ARCH} /src/scripts/binonly.sh
+	docker run --rm -v $(pwd)/out:/out --security-opt label=disable -e ARCH=${ARCH} genie-builder:${ARCH} /src/scripts/binonly.sh
 	exit ${?}
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,23 +7,23 @@ set -ex
 if test "$IP_ADDRESS" = "adb" ; then
     if [ ${LIGHT} -eq 0 ]; then
         adb shell "rm -fr /opt/genie ; mkdir -p /opt/genie/lib/gio/modules /opt/genie/lib/gstreamer-1.0 /opt/genie/assets"
-        adb push build/lib /opt/genie
-        adb push build/assets /opt/genie
+        adb push out/lib /opt/genie
+        adb push out/assets /opt/genie
     fi
     adb push scripts/launch.sh /opt/duer/dcslaunch.sh
-    test -f build/config.ini && adb push build/config.ini /opt/genie/config.ini
+    test -f out/config.ini && adb push out/config.ini /opt/genie/config.ini
     adb push scripts/asoundrc /opt/genie/.asoundrc
-    adb push build/src/genie /opt/genie/genie
+    adb push out/src/genie /opt/genie/genie
 else
     if [ ${LIGHT} -eq 0 ]; then
         ssh root@$IP_ADDRESS "rm -fr /opt/genie"
         sleep 1
         ssh root@$IP_ADDRESS "mkdir -p /opt/genie"
-        scp -r build/lib root@$IP_ADDRESS:/opt/genie/
-        scp -r build/assets root@$IP_ADDRESS:/opt/genie/
+        scp -r out/lib root@$IP_ADDRESS:/opt/genie/
+        scp -r out/assets root@$IP_ADDRESS:/opt/genie/
     fi
     scp scripts/launch.sh root@$IP_ADDRESS:/opt/duer/dcslaunch.sh
-    test -f build/config.ini && scp build/config.ini root@$IP_ADDRESS:/opt/genie/
+    test -f out/config.ini && scp out/config.ini root@$IP_ADDRESS:/opt/genie/
     scp scripts/asoundrc root@$IP_ADDRESS:/opt/genie/.asoundrc
-    scp build/src/genie root@$IP_ADDRESS:/opt/genie/
+    scp out/src/genie root@$IP_ADDRESS:/opt/genie/
 fi

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,7 +10,7 @@ _onlySharedDeps = [ 'gstreamer-1.0', 'alsa' ]
 _alwaysSharedDeps = [ 'gio-2.0' ]
 
 _linkArgs = []
-_incDirs = []
+_incDirs = include_directories('../deps/tinyfsm/include')
 _deps = []
 
 _deps += cpp.find_library('dl')
@@ -85,5 +85,6 @@ executable(
   link_args : _linkArgs,
   cpp_args : ['-DG_LOG_USE_STRUCTURED=1'],
   install : true,
-  dependencies : _deps
+  dependencies : _deps,
+  include_directories : _incDirs,
 )


### PR DESCRIPTION
Changes for VSCode to run in an arm32v7 dev container

Biggest change is renaming the `/build` directory to `/out` (where the output get copied too from the build container). This is to allow meson to use `/build` in the dev container setup.

Also includes tinysfm as a submodule due to how the commit history happen; we can remove that if we end up not using it.