### PR TITLE
State events for all, private app components

### DIFF
--- a/src/app.hpp
+++ b/src/app.hpp
@@ -100,24 +100,14 @@ public:
   
   template <typename E>
   guint dispatch(E *event) {
-    return m_state_machine->dispatch(event);
+    return state_machine->dispatch(event);
   }
 
   SoupSession* get_soup_session() {
-    return m_soup_session.get();
+    return soup_session.get();
   }
 
-  GMainLoop *main_loop;
-  std::unique_ptr<Config> m_config;
-  std::unique_ptr<AudioInput> m_audioInput;
-  std::unique_ptr<AudioFIFO> m_audioFIFO;
-  std::unique_ptr<AudioPlayer> m_audioPlayer;
-  std::unique_ptr<EVInput> m_evInput;
-  std::unique_ptr<Leds> m_leds;
-  std::unique_ptr<Spotifyd> m_spotifyd;
-  std::unique_ptr<STT> m_stt;
-  std::unique_ptr<ConversationClient> conversation_client;
-  std::unique_ptr<DNSController> m_dns_controller;
+  std::unique_ptr<Config> config;
 
 private:
 // ===========================================================================
@@ -125,9 +115,20 @@ private:
   // Private Instance Members
   // =========================================================================
   
-  std::unique_ptr<state::Machine> m_state_machine;
-
-  auto_gobject_ptr<SoupSession> m_soup_session;
+  GMainLoop *main_loop;
+  auto_gobject_ptr<SoupSession> soup_session;
+  
+  // ### Component Instances ###
+  
+  std::unique_ptr<AudioInput> audio_input;
+  std::unique_ptr<AudioPlayer> audio_player;
+  std::unique_ptr<ConversationClient> conversation_client;
+  std::unique_ptr<DNSController> dns_controller;
+  std::unique_ptr<EVInput> ev_input;
+  std::unique_ptr<Leds> leds;
+  std::unique_ptr<Spotifyd> spotifyd;
+  std::unique_ptr<state::Machine> state_machine;
+  std::unique_ptr<STT> stt;
 
   gboolean isProcessing;
   struct timeval tStartProcessing;

--- a/src/audiofifo.cpp
+++ b/src/audiofifo.cpp
@@ -41,13 +41,13 @@ genie::AudioFIFO::~AudioFIFO() {
 
 int genie::AudioFIFO::init() {
   struct stat st;
-  if (stat(app->m_config->audioOutputFIFO, &st) != 0) {
-    mkfifo(app->m_config->audioOutputFIFO, 0666);
+  if (stat(app->config->audioOutputFIFO, &st) != 0) {
+    mkfifo(app->config->audioOutputFIFO, 0666);
   }
 
-  fd = open(app->m_config->audioOutputFIFO, O_RDONLY | O_NONBLOCK);
+  fd = open(app->config->audioOutputFIFO, O_RDONLY | O_NONBLOCK);
   if (fd < 0) {
-    g_printerr("failed to open %s, error %d\n", app->m_config->audioOutputFIFO, fd);
+    g_printerr("failed to open %s, error %d\n", app->config->audioOutputFIFO, fd);
     return false;
   }
 

--- a/src/audioinput.cpp
+++ b/src/audioinput.cpp
@@ -47,15 +47,10 @@ genie::AudioInput::~AudioInput() {
   snd_pcm_close(alsa_handle);
   pv_porcupine_delete_func(porcupine);
   dlclose(porcupine_library);
-#ifdef DEBUG_DUMP_STREAMS
-  fclose(fp_input);
-  fclose(fp_output);
-  fclose(fp_filter);
-#endif
 }
 
 int genie::AudioInput::init() {
-  gchar *input_audio_device = app->m_config->audioInputDevice;
+  gchar *input_audio_device = app->config->audioInputDevice;
 
   const char *library_path = "assets/libpv_porcupine.so";
   const char *model_path = "assets/porcupine_params.pv";
@@ -246,33 +241,19 @@ int genie::AudioInput::init() {
   }
 
   vad_start_frame_count = ms_to_frames(AUDIO_INPUT_VAD_FRAME_LENGTH,
-                                       app->m_config->vad_start_speaking_ms);
+                                       app->config->vad_start_speaking_ms);
   g_message("Calculated start VAD: %d ms -> %d frames",
-            app->m_config->vad_start_speaking_ms, vad_start_frame_count);
+            app->config->vad_start_speaking_ms, vad_start_frame_count);
 
   vad_done_frame_count = ms_to_frames(AUDIO_INPUT_VAD_FRAME_LENGTH,
-                                      app->m_config->vad_done_speaking_ms);
+                                      app->config->vad_done_speaking_ms);
   g_message("Calculated done VAD: %d ms -> %d frames",
-            app->m_config->vad_done_speaking_ms, vad_done_frame_count);
+            app->config->vad_done_speaking_ms, vad_done_frame_count);
 
   min_woke_frame_count = ms_to_frames(AUDIO_INPUT_VAD_FRAME_LENGTH,
-                                      app->m_config->vad_min_woke_ms);
+                                      app->config->vad_min_woke_ms);
   g_message("Calculated min woke frames: %d ms -> %d frames",
-            app->m_config->vad_min_woke_ms, min_woke_frame_count);
-
-  echo_state = speex_echo_state_init_mc(
-      pv_frame_length, ms_to_frames(AUDIO_INPUT_VAD_FRAME_LENGTH, 500), 1, 1);
-  speex_echo_ctl(echo_state, SPEEX_ECHO_SET_SAMPLING_RATE, &(sample_rate));
-
-  PaUtil_AdvanceRingBufferReadIndex(
-      &app->m_audioFIFO.get()->ring_buffer,
-      PaUtil_GetRingBufferReadAvailable(&app->m_audioFIFO.get()->ring_buffer));
-
-#ifdef DEBUG_DUMP_STREAMS
-  fp_input = fopen("/tmp/input.raw", "wb+");
-  fp_output = fopen("/tmp/playback.raw", "wb+");
-  fp_filter = fopen("/tmp/filter.raw", "wb+");
-#endif
+            app->config->vad_min_woke_ms, min_woke_frame_count);
 
   GError *thread_error = NULL;
   g_thread_try_new("audioInputThread", (GThreadFunc)loop, this, &thread_error);

--- a/src/audioplayer.cpp
+++ b/src/audioplayer.cpp
@@ -162,9 +162,9 @@ bool genie::AudioPlayer::playURI(const std::string &uri,
     return false;
 
   auto sink = auto_gst_ptr<GstElement>(
-      gst_element_factory_make(app->m_config->audioSink, "audio-output"),
+      gst_element_factory_make(app->config->audioSink, "audio-output"),
       adopt_mode::ref_sink);
-  const char *output_device = getAudioOutput(*app->m_config, destination);
+  const char *output_device = getAudioOutput(*app->config, destination);
   if (output_device)
     g_object_set(G_OBJECT(sink.get()), "device", output_device, NULL);
 
@@ -192,14 +192,14 @@ bool genie::AudioPlayer::say(const std::string &text, gint64 ref_id) {
                                            adopt_mode::ref_sink);
   source = gst_element_factory_make("souphttpsrc", "http-source");
   decoder = gst_element_factory_make("wavparse", "wav-parser");
-  sink = gst_element_factory_make(app->m_config->audioSink, "audio-output");
+  sink = gst_element_factory_make(app->config->audioSink, "audio-output");
 
   if (!pipeline || !source || !decoder || !sink) {
     g_printerr("Gst element could not be created\n");
     return false;
   }
 
-  gchar *location = g_strdup_printf("%s/en-US/voice/tts", app->m_config->nlURL);
+  gchar *location = g_strdup_printf("%s/en-US/voice/tts", app->config->nlURL);
   g_object_set(G_OBJECT(source), "location", location, NULL);
   g_free(location);
   g_object_set(G_OBJECT(source), "method", "POST", NULL);
@@ -212,7 +212,7 @@ bool genie::AudioPlayer::say(const std::string &text, gint64 ref_id) {
   json_builder_add_string_value(builder, text.c_str());
 
   json_builder_set_member_name(builder, "gender");
-  json_builder_add_string_value(builder, app->m_config->audioVoice);
+  json_builder_add_string_value(builder, app->config->audioVoice);
 
   json_builder_end_object(builder);
 
@@ -229,7 +229,7 @@ bool genie::AudioPlayer::say(const std::string &text, gint64 ref_id) {
   g_object_unref(builder);
 
   const char *output_device =
-      getAudioOutput(*app->m_config, AudioDestination::VOICE);
+      getAudioOutput(*app->config, AudioDestination::VOICE);
   if (output_device) {
     g_object_set(G_OBJECT(sink), "device", output_device, NULL);
   }
@@ -311,7 +311,7 @@ genie::AudioPlayer::get_mixer_element(snd_mixer_t *handle,
   snd_mixer_selem_id_t *sid;
 
   snd_mixer_open(&handle, 0);
-  snd_mixer_attach(handle, app->m_config->audio_output_device);
+  snd_mixer_attach(handle, app->config->audio_output_device);
   snd_mixer_selem_register(handle, NULL, NULL);
   snd_mixer_load(handle);
 
@@ -328,7 +328,7 @@ int genie::AudioPlayer::adjust_playback_volume(long delta) {
   snd_mixer_selem_id_t *sid;
 
   snd_mixer_open(&handle, 0);
-  snd_mixer_attach(handle, app->m_config->audio_output_device);
+  snd_mixer_attach(handle, app->config->audio_output_device);
   snd_mixer_selem_register(handle, NULL, NULL);
   snd_mixer_load(handle);
 

--- a/src/conversation_client.cpp
+++ b/src/conversation_client.cpp
@@ -77,7 +77,7 @@ void genie::ConversationClient::maybe_flush_queue() {
   m_outgoing_queue.clear();
 }
 
-void genie::ConversationClient::send_command(const char *data) {
+void genie::ConversationClient::send_command(const std::string text) {
   auto_gobject_ptr<JsonBuilder> builder(json_builder_new(), adopt_mode::owned);
 
   json_builder_begin_object(builder.get());
@@ -86,7 +86,7 @@ void genie::ConversationClient::send_command(const char *data) {
   json_builder_add_string_value(builder.get(), "command");
 
   json_builder_set_member_name(builder.get(), "text");
-  json_builder_add_string_value(builder.get(), data);
+  json_builder_add_string_value(builder.get(), text.c_str());
 
   json_builder_end_object(builder.get());
 
@@ -363,8 +363,8 @@ void genie::ConversationClient::on_connection(SoupSession *session,
 genie::ConversationClient::ConversationClient(App *appInstance) {
   app = appInstance;
   conversationId = NULL;
-  accessToken = g_strdup(app->m_config->genieAccessToken);
-  url = g_strdup(app->m_config->genieURL);
+  accessToken = g_strdup(app->config->genieAccessToken);
+  url = g_strdup(app->config->genieURL);
 
   tInit = false;
   lastSaidTextID = -1;
@@ -382,9 +382,9 @@ void genie::ConversationClient::connect() {
   SoupMessage *msg;
 
   SoupURI *uri = soup_uri_new(url);
-  if (app->m_config->conversationId) {
+  if (app->config->conversationId) {
     soup_uri_set_query_from_fields(uri, "skip_history", "1", "sync_devices",
-                                   "1", "id", app->m_config->conversationId,
+                                   "1", "id", app->config->conversationId,
                                    nullptr);
   } else {
     soup_uri_set_query_from_fields(uri, "skip_history", "1", "sync_devices",

--- a/src/conversation_client.hpp
+++ b/src/conversation_client.hpp
@@ -19,11 +19,11 @@
 #pragma once
 
 #include "app.hpp"
+#include "autoptrs.hpp"
 #include <deque>
 #include <json-glib/json-glib.h>
 #include <libsoup/soup.h>
-
-#include "autoptrs.hpp"
+#include <string>
 
 namespace genie {
 
@@ -33,7 +33,7 @@ public:
   ~ConversationClient();
 
   int init();
-  void send_command(const char *data);
+  void send_command(const std::string text);
   void send_thingtalk(const char *data);
 
 protected:

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -32,10 +32,10 @@ genie::Leds::~Leds() {}
 int genie::Leds::init() { return true; }
 
 void genie::Leds::set_active(bool active) {
-  if (!app->m_config->leds_path)
+  if (!app->config->leds_path)
     return;
 
-  int fd = open(app->m_config->leds_path, O_WRONLY);
+  int fd = open(app->config->leds_path, O_WRONLY);
   if (fd > 0) {
     write(fd, active ? "1" : "0", 1);
   }

--- a/src/spotifyd.cpp
+++ b/src/spotifyd.cpp
@@ -108,9 +108,9 @@ int genie::Spotifyd::spawn() {
       "--device-type", "speaker",        "--backend",     backend,
       "--username",    username.c_str(), "--token",       access_token.c_str(),
   };
-  if (strcmp(backend, "alsa") == 0 && app->m_config->audioOutputDeviceMusic) {
+  if (strcmp(backend, "alsa") == 0 && app->config->audioOutputDeviceMusic) {
     argv.push_back("--device");
-    argv.push_back(app->m_config->audioOutputDeviceMusic);
+    argv.push_back(app->config->audioOutputDeviceMusic);
   }
   argv.push_back(nullptr);
 

--- a/src/state/events.hpp
+++ b/src/state/events.hpp
@@ -109,6 +109,26 @@ struct PlayerStreamEnd : Event {
       : type(type), ref_id(ref_id) {}
 };
 
+// Speech-To-Text (STT) Events
+// ===========================================================================
+
+namespace stt {
+
+struct TextResponse : Event {
+  std::string text;
+
+  TextResponse(const char *text) : text(text) {}
+};
+
+struct ErrorResponse : Event {
+  int code;
+  std::string message;
+
+  ErrorResponse(int code, const char *message) : code(code), message(message) {}
+};
+
+} // namespace stt
+
 } // namespace events
 } // namespace state
 } // namespace genie

--- a/src/state/follow_up.cpp
+++ b/src/state/follow_up.cpp
@@ -17,6 +17,7 @@
 // limitations under the License.
 
 #include "app.hpp"
+#include "audioplayer.hpp"
 
 #undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "genie::state::FollowUp"

--- a/src/state/listening.cpp
+++ b/src/state/listening.cpp
@@ -18,6 +18,8 @@
 
 #include "app.hpp"
 #include "stt.hpp"
+#include "audioinput.hpp"
+#include "audioplayer.hpp"
 
 #undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "genie::state::Listening"
@@ -29,14 +31,14 @@ Listening::Listening(Machine *machine) : State{machine} {}
 
 void Listening::enter() {
   g_message("ENTER state Listening\n");
-  app->m_audioInput->wake();
+  app->audio_input->wake();
   app->duck();
   g_message("Stopping audio player...\n");
-  app->m_audioPlayer->stop();
+  app->audio_player->stop();
   g_message("Playing match sound...\n");
-  app->m_audioPlayer->playSound(SOUND_MATCH);
+  app->audio_player->playSound(SOUND_MATCH);
   g_message("Connecting STT...\n");
-  app->m_stt->begin_session();
+  app->stt->begin_session();
 }
   
 void Listening::react(events::Wake *) {
@@ -44,30 +46,30 @@ void Listening::react(events::Wake *) {
 }
 
 void Listening::react(events::InputFrame *input_frame) {
-  app->m_stt->send_frame(std::move(input_frame->frame));
+  app->stt->send_frame(std::move(input_frame->frame));
 }
 
 void Listening::react(events::InputDone *) {
   g_message("Handling InputDone...\n");
-  app->m_stt->send_done();
-  app->m_audioPlayer->stop();
-  app->m_audioPlayer->playSound(SOUND_MATCH);
+  app->stt->send_done();
+  app->audio_player->stop();
+  app->audio_player->playSound(SOUND_MATCH);
   machine->transit<Sleeping>();
 }
 
 void Listening::react(events::InputNotDetected *) {
   g_message("Handling InputNotDetected...\n");
-  app->m_stt->abort();
-  app->m_audioPlayer->stop();
-  app->m_audioPlayer->playSound(SOUND_NO_MATCH);
+  app->stt->abort();
+  app->audio_player->stop();
+  app->audio_player->playSound(SOUND_NO_MATCH);
   machine->transit<Sleeping>();
 }
 
 void Listening::react(events::InputTimeout *) {
   g_message("Handling InputTimeout...\n");
-  app->m_stt->abort();
-  app->m_audioPlayer->stop();
-  app->m_audioPlayer->playSound(SOUND_NO_MATCH);
+  app->stt->abort();
+  app->audio_player->stop();
+  app->audio_player->playSound(SOUND_NO_MATCH);
   machine->transit<Sleeping>();
 }
 

--- a/src/state/state.hpp
+++ b/src/state/state.hpp
@@ -52,6 +52,8 @@ public:
   virtual void react(events::SpotifyCredentials *spotify_credentials);
   virtual void react(events::AdjustVolume *adjust_volume);
   virtual void react(events::PlayerStreamEnd *player_stream_end);
+  virtual void react(events::stt::TextResponse *response);
+  virtual void react(events::stt::ErrorResponse *response);
 };
 
 } // namespace state

--- a/src/stt.hpp
+++ b/src/stt.hpp
@@ -22,9 +22,6 @@
 #include <libsoup/soup.h>
 
 #include "app.hpp"
-#include "audioinput.hpp"
-#include "audioplayer.hpp"
-#include "conversation_client.hpp"
 #include "autoptrs.hpp"
 #include <queue>
 


### PR DESCRIPTION
No more direct cross-component calls, everything uses state events. Component instances are now private members of `genie::App`.

Also dropped the `m_` prefix from `genie::App` member names.