### PR TITLE
Hopefully fix perf logging with new PlayerStreamEnter event

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -150,6 +150,8 @@ void genie::App::track_processing_event(ProcessingEventType event_type) {
       break;
     case ProcessingEventType::END_TTS:
       gettimeofday(&end_tts, NULL);
+      break;
+    case ProcessingEventType::DONE:
       int total_ms = time_diff_ms(start_stt, end_tts);
 
       g_print("############# Processing Performance #################\n");

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -74,13 +74,13 @@ class Client;
 }
 
 enum class ProcessingEventType {
-  BEGIN,
   START_STT,
   END_STT,
   START_GENIE,
   END_GENIE,
   START_TTS,
   END_TTS,
+  DONE,
 };
 
 class App {

--- a/src/audioplayer.cpp
+++ b/src/audioplayer.cpp
@@ -64,7 +64,8 @@ gboolean genie::AudioPlayer::bus_call_queue(GstBus *bus, GstMessage *msg,
       // times, with the second time over-writing the first, which results
       // in the desired state.
       if (type == GST_STREAM_STATUS_TYPE_ENTER) {
-        obj->app->track_processing_event(ProcessingEventType::END_TTS);
+        obj->app->dispatch(new state::events::PlayerStreamEnter(
+            obj->playingTask->type, obj->playingTask->ref_id));
       }
       break;
     case GST_MESSAGE_EOS:

--- a/src/state/events.hpp
+++ b/src/state/events.hpp
@@ -158,6 +158,14 @@ struct TogglePlayback : Event {};
 // Audio Player Events
 // ===========================================================================
 
+struct PlayerStreamEnter : Event {
+  AudioTaskType type;
+  gint64 ref_id;
+
+  PlayerStreamEnter(AudioTaskType type, gint64 ref_id)
+      : type(type), ref_id(ref_id) {}
+};
+
 struct PlayerStreamEnd : Event {
   AudioTaskType type;
   gint64 ref_id;

--- a/src/state/saying.cpp
+++ b/src/state/saying.cpp
@@ -46,8 +46,15 @@ void Saying::react(events::AskSpecialMessage *ask_special_message) {
   }
 }
 
+void Saying::react(events::PlayerStreamEnter *player_stream_enter) {
+  if (player_stream_enter->ref_id == text_id) {
+    app->track_processing_event(ProcessingEventType::END_TTS);
+  }
+}
+
 void Saying::react(events::PlayerStreamEnd *player_stream_end) {
   if (player_stream_end->ref_id == text_id) {
+    app->track_processing_event(ProcessingEventType::DONE);
     if (follow_up) {
       app->transit(new Listening(app));
     } else {

--- a/src/state/saying.hpp
+++ b/src/state/saying.hpp
@@ -34,6 +34,7 @@ public:
   void enter() override;
 
   void react(events::AskSpecialMessage *ask_special_message) override;
+  void react(events::PlayerStreamEnter *player_stream_enter) override;
   void react(events::PlayerStreamEnd *player_stream_end) override;
 
 private:

--- a/src/state/state.cpp
+++ b/src/state/state.cpp
@@ -94,6 +94,12 @@ void State::react(events::TogglePlayback *) {
   g_warning("TODO Playback toggled in state %s", NAME);
 }
 
+void State::react(events::PlayerStreamEnter *player_stream_enter) {
+  g_message("Received PlayerStreamEnter with type=%d ref_id=%" G_GINT64_FORMAT
+            ", ignoring.",
+            (int)player_stream_enter->type, player_stream_enter->ref_id);
+}
+
 void State::react(events::PlayerStreamEnd *player_stream_end) {
   g_message("Received PlayerStreamEnd with type=%d ref_id=%" G_GINT64_FORMAT
             ", ignoring.",

--- a/src/state/state.hpp
+++ b/src/state/state.hpp
@@ -55,6 +55,7 @@ public:
   virtual void react(events::SpotifyCredentials *spotify_credentials);
   virtual void react(events::AdjustVolume *adjust_volume);
   virtual void react(events::TogglePlayback *);
+  virtual void react(events::PlayerStreamEnter *player_stream_enter);
   virtual void react(events::PlayerStreamEnd *player_stream_end);
   virtual void react(events::stt::TextResponse *response);
   virtual void react(events::stt::ErrorResponse *response);


### PR DESCRIPTION
We need to know _what_ pipeline we're talking about when we deal with entering a stream, as far as figuring out when TTS ends (which is when our "processing" time chunk ends).