### PR TITLE
Lights on through end of TTS and conditional wake-word presence check

### DIFF
--- a/src/state/listening.cpp
+++ b/src/state/listening.cpp
@@ -32,12 +32,12 @@ namespace state {
 void Listening::enter() {
   g_message("ENTER state Listening\n");
   app->leds->set_active(true);
-  app->stt->begin_session();
+  app->stt->begin_session(is_follow_up);
   app->audio_input->wake();
   app->duck();
   g_message("Stopping audio player...\n");
   app->audio_player->stop();
-  if (play_wake_sound) {
+  if (!is_follow_up) {
     g_message("Playing WAKE sound...\n");
     app->audio_player->play_sound(Sound_t::WAKE);
   }

--- a/src/state/listening.hpp
+++ b/src/state/listening.hpp
@@ -29,8 +29,8 @@ public:
   static const constexpr char *NAME = "Listening";
 
   Listening(App *app) : State{app} {}
-  Listening(App *app, bool play_wake_sound)
-      : State{app}, play_wake_sound(play_wake_sound) {}
+  Listening(App *app, bool is_follow_up)
+      : State{app}, is_follow_up(is_follow_up) {}
 
   void enter() override;
 
@@ -41,7 +41,7 @@ public:
   void react(events::InputTimeout *) override;
 
 private:
-  bool play_wake_sound = true;
+  bool is_follow_up = false;
 };
 
 } // namespace state

--- a/src/state/processing.cpp
+++ b/src/state/processing.cpp
@@ -49,7 +49,9 @@ void Processing::react(events::stt::ErrorResponse *response) {
   app->track_processing_event(ProcessingEventType::END_STT);
   g_warning("STT completed with an error (code=%d): %s", response->code,
             response->message.c_str());
-  app->audio_player.get()->play_sound(Sound_t::STT_ERROR);
+  if (response->code != 404) {
+    app->audio_player.get()->play_sound(Sound_t::STT_ERROR);
+  }
   app->transit(new Sleeping(app));
 }
 

--- a/src/state/saying.cpp
+++ b/src/state/saying.cpp
@@ -19,7 +19,6 @@
 #include "state/saying.hpp"
 #include "app.hpp"
 #include "audioplayer.hpp"
-#include "leds.hpp"
 
 #undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "genie::state::Saying"
@@ -28,7 +27,6 @@ namespace genie {
 namespace state {
 
 void Saying::enter() {
-  app->leds->set_active(false);
   app->track_processing_event(ProcessingEventType::START_TTS);
   app->audio_player->say(text, text_id);
 }

--- a/src/state/sleeping.cpp
+++ b/src/state/sleeping.cpp
@@ -19,6 +19,7 @@
 #include "state/sleeping.hpp"
 #include "app.hpp"
 #include "audioplayer.hpp"
+#include "leds.hpp"
 
 #undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "genie::state::Sleeping"
@@ -28,6 +29,7 @@ namespace state {
 
 void Sleeping::enter() {
   g_message("ENTER state Sleeping\n");
+  app->leds->set_active(false);
   app->unduck();
 }
 

--- a/src/stt.hpp
+++ b/src/stt.hpp
@@ -47,11 +47,12 @@ private:
   std::queue<AudioFrame> queue;
   auto_gobject_ptr<SoupWebsocketConnection> m_connection;
   bool m_done;
+  bool is_follow_up;
 
   void handle_stt_result(const char *text);
 
 public:
-  STTSession(STT *controller, const char *url);
+  STTSession(STT *controller, const char *url, bool is_follow_up);
   ~STTSession();
 
   static void on_connection(SoupSession *session, GAsyncResult *res,
@@ -76,7 +77,7 @@ class STT {
 public:
   STT(App *app);
 
-  void begin_session();
+  void begin_session(bool is_follow_up);
   void send_frame(AudioFrame frame);
   void send_done();
   void abort();


### PR DESCRIPTION
1. Lights stay on through the end of Saying (TTS) state
2. Presence of wake-word is checked (against the regex) _unless_ we are doing a follow-up. If the wake-word is _not_ found we silently abort the round.